### PR TITLE
pyxis: Build vendor variant of vendor.goodix.hardware.biometrics.fingerprint@2.1

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -68,6 +68,7 @@ PRODUCT_PACKAGES += \
 # Fingerprint
 PRODUCT_PACKAGES += \
     android.hardware.biometrics.fingerprint@2.1-service.xiaomi_sdm710 \
+    vendor.goodix.hardware.biometrics.fingerprint@2.1.vendor:64 \
     vendor.lineage.biometrics.fingerprint.inscreen@1.0-service.xiaomi_sdm710
 
 PRODUCT_COPY_FILES += \

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -295,7 +295,6 @@ vendor/lib64/hw/fingerprint.goodix_fod.so:vendor/lib64/hw/fingerprint.goodix_fod
 vendor/lib64/libarm_proxy_skel.so
 vendor/lib64/libgf_hal.so
 vendor/lib64/libhvx_proxy_stub.so
-vendor/lib64/vendor.goodix.hardware.biometrics.fingerprint@2.1.so
 
 # GPS
 vendor/bin/loc_launcher


### PR DESCRIPTION
This has to be explicitly specified otherwise only system (!!) variant will be
built instead. Our fingerprint HAL needs vendor variant.

Signed-off-by: Albert I <kras@raphielgang.org>
Signed-off-by: Alex Damaratski <alexeydomoratsky1@gmail.com>
Change-Id: I2e05ba8f8829e6b2d402435801f509f7bce88884