### PR TITLE
Require A11 firmware and fix L1 DRM

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,1 @@
-require version-trustzone=XF.5.0.2.C5-00006
+require version-trustzone=XF.5.0.2-00229

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -250,6 +250,15 @@ vendor/lib64/vendor.xiaomi.hardware.mtdservice@1.1.so
 vendor/lib64/vendor.xiaomi.hardware.mtdservice@1.2.so
 
 # DRM (Widevine)
+modem/image/widevine.b00:vendor/firmware/widevine.b00
+modem/image/widevine.b01:vendor/firmware/widevine.b01
+modem/image/widevine.b02:vendor/firmware/widevine.b02
+modem/image/widevine.b03:vendor/firmware/widevine.b03
+modem/image/widevine.b04:vendor/firmware/widevine.b04
+modem/image/widevine.b05:vendor/firmware/widevine.b05
+modem/image/widevine.b06:vendor/firmware/widevine.b06
+modem/image/widevine.b07:vendor/firmware/widevine.b07
+modem/image/widevine.mdt:vendor/firmware/widevine.mdt
 vendor/bin/hw/android.hardware.drm@1.2-service.widevine
 vendor/etc/init/android.hardware.drm@1.2-service.widevine.rc
 vendor/lib64/libhdcpsrm.so


### PR DESCRIPTION
A10 firmware on new A11 blobs causes high idle drain so we need to require A11 FW.
On other side A11 firmware is chinese only and does not provide Widevine blobs.
Fortunately DRM HAL does not look for firmware files only in /vendor/firmware_mnt but also /vendor/firmware so we can ship widevine firmware together with ROM.