### PR TITLE
pyxis: decommonize sensors blobs

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -349,8 +349,34 @@ vendor/lib/hw/android.hardware.secure_element@1.0-impl.so
 vendor/lib64/hw/android.hardware.secure_element@1.0-impl.so
 
 # Sensors
-vendor/lib/sensors.ssc.so
+vendor/bin/hw/vendor.qti.hardware.sensorscalibrate@1.0-service
+vendor/bin/sensors.qti
+vendor/etc/init/vendor.qti.hardware.sensorscalibrate@1.0-service.rc
+vendor/etc/permissions/vendor-qti-hardware-sensorscalibrate.xml
+vendor/lib64/hw/vendor.qti.hardware.sensorscalibrate@1.0-impl.so
+vendor/lib64/libsensorcal.so
+vendor/lib64/libsensorslog.so
+vendor/lib64/libssc.so
+vendor/lib64/libssc_default_listener.so
+vendor/lib64/libssccalapi.so
+vendor/lib64/libsns_device_mode_stub.so
+vendor/lib64/libsns_fastRPC_util.so
+vendor/lib64/libsns_low_lat_stream_stub.so
+vendor/lib64/libsnsdiaglog.so
 vendor/lib64/sensors.ssc.so
+vendor/lib64/vendor.qti.hardware.sensorscalibrate@1.0.so
+vendor/lib/hw/vendor.qti.hardware.sensorscalibrate@1.0-impl.so
+vendor/lib/libsensorcal.so
+vendor/lib/libsensorslog.so
+vendor/lib/libssc.so
+vendor/lib/libssc_default_listener.so
+vendor/lib/libssccalapi.so
+vendor/lib/libsns_device_mode_stub.so
+vendor/lib/libsns_fastRPC_util.so
+vendor/lib/libsns_low_lat_stream_stub.so
+vendor/lib/libsnsdiaglog.so
+vendor/lib/sensors.ssc.so
+vendor/lib/vendor.qti.hardware.sensorscalibrate@1.0.so
 
 # Sensor configs
 vendor/etc/sensors/config/adux1050_0.json


### PR DESCRIPTION
Sensors HAL are tightly connected with camera HAL. Due to facts that
sirius probably will not receive A11 update and camera HAL is highly
device specific we have to move sensors HAL to device trees to be
able to update them on other devices.